### PR TITLE
Add exported method for forcing a consumer group rebalance

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/sarama"
+	"github.com/ORBAT/sarama"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/cluster/consumer_group.go
+++ b/cluster/consumer_group.go
@@ -257,6 +257,12 @@ func (cg *ConsumerGroup) nextConsumer() *PartitionConsumer {
 	return &shift
 }
 
+// ForceRebalance releases all claims and starts a rebalance cycle
+func (cg *ConsumerGroup) ForceRebalance() {
+	cg.releaseClaims()
+	cg.force <- true
+}
+
 // Start a rebalance cycle
 func (cg *ConsumerGroup) rebalance() (err error) {
 	var cids []string

--- a/cluster/consumer_group.go
+++ b/cluster/consumer_group.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/Shopify/sarama"
+	"github.com/ORBAT/sarama"
 	"github.com/samuel/go-zookeeper/zk"
 )
 
@@ -109,6 +109,8 @@ func (cg *ConsumerGroup) Name() string {
 func (cg *ConsumerGroup) Topic() string {
 	return cg.topic
 }
+
+// BUG(ORBAT): Checkout() will fail to commit the offset if the claimed offset was 0
 
 // Checkout applies a callback function to a single partition consumer.
 // The latest consumer offset is automatically comitted to zookeeper if successful.

--- a/cluster/consumer_group_test.go
+++ b/cluster/consumer_group_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/Shopify/sarama"
+	"github.com/ORBAT/sarama"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/cluster/consumer_group_test.go
+++ b/cluster/consumer_group_test.go
@@ -197,6 +197,41 @@ var _ = Describe("ConsumerGroup", func() {
 			Expect(now).To(Equal(was + 16))
 		})
 
+		It("should allow forcing a rebalance", func() {
+			was, _ := subject.Offset(0)
+
+			var batch *EventBatch
+			okCount := int64(5)
+
+			err := subject.Process(func(b *EventBatch) error {
+				// here we successfully "process" okCount-1 events out of the batch, but then things go pear-shaped and we're left with a partially processed EventBatch
+				// frob(b)
+				batch = b
+				return mockError
+			})
+
+			Expect(err).To(Equal(mockError))
+			Expect(batch).NotTo(BeNil())
+			Expect(batch.Events).To(HaveLen(16))
+
+			// let's manually commit the offset so that it points to the message our previous Process() errored on
+			cerr := subject.Commit(0, was+okCount)
+			Expect(cerr).NotTo(HaveOccurred())
+			now, _ := subject.Offset(0)
+			Expect(now).To(Equal(was + okCount))
+			subject.ForceRebalance()
+
+			err = subject.Process(func(b *EventBatch) error {
+				Expect(b.Events[0].Offset).To(Equal(int64(was + okCount)))
+				Expect(b.Events[len(b.Events)-1].Offset).To(Equal(was + okCount + int64(len(b.Events)) - 1))
+				return nil // no errors this time, yay!
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			now, _ = subject.Offset(0)
+			Expect(now).To(Equal(was + okCount + 16))
+		})
+
 		It("should skip commits if requested", func() {
 			was, _ := subject.Offset(0)
 			err := subject.Process(func(b *EventBatch) error { return DiscardCommit })

--- a/cluster/partition_consumer.go
+++ b/cluster/partition_consumer.go
@@ -1,6 +1,6 @@
 package cluster
 
-import "github.com/Shopify/sarama"
+import "github.com/ORBAT/sarama"
 
 // EventStream is an abstraction of a sarama.Consumer
 type EventStream interface {

--- a/cluster/partition_consumer_test.go
+++ b/cluster/partition_consumer_test.go
@@ -1,7 +1,7 @@
 package cluster
 
 import (
-	"github.com/Shopify/sarama"
+	"github.com/ORBAT/sarama"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
I added a `ConsumerGroup#ForceRebalance()`method to allow forcing a rebalance. This allows the next call to `ConsumerGroup#Process()` to resume at a manually committed offset (when e.g. the last `Process()` didn't successfully process all the events it got)
